### PR TITLE
Bugfix block duplicate favourites

### DIFF
--- a/db/schema/03_favorites.sql
+++ b/db/schema/03_favorites.sql
@@ -4,5 +4,6 @@ DROP TABLE IF EXISTS favorites CASCADE;
 CREATE TABLE favorites (
   id SERIAL PRIMARY KEY NOT NULL,
   item_id INTEGER REFERENCES items(id) ON DELETE CASCADE,
-  buyer_id INTEGER REFERENCES users(id) ON DELETE CASCADE
+  buyer_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  unique(item_id, buyer_id)
 );

--- a/routes/favorites.js
+++ b/routes/favorites.js
@@ -51,6 +51,7 @@ module.exports = (db) => {
     let queryString = `
     INSERT INTO favorites (item_id, buyer_id)
     VALUES($1, $2)
+    ON CONFLICT (item_id, buyer_id) DO NOTHING
     RETURNING *;`;
 
     db.query(queryString, [req.params.id, req.session.user_id])


### PR DESCRIPTION
Howdy! Found a very direct path to solving this problem with a little research. Here are the resources that I learned from along the way:
[Stack: ON CONFLICT Clause with RETURNING](https://stackoverflow.com/questions/34708509/how-to-use-returning-with-on-conflict-in-postgresql/42217872#42217872)
[Postgres Docs: ON CONFLICT Clause](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)
[Stack: Unique Constraint](https://stackoverflow.com/questions/42022362/no-unique-or-exclusion-constraint-matching-the-on-conflict)

This should complement April's fix by preventing duplicates from getting into the database! :) 

(Let's delete this branch once it's merged in!)